### PR TITLE
Allow x to be a list, rather than having to provide the name of a list

### DIFF
--- a/R/WriteXLS.R
+++ b/R/WriteXLS.R
@@ -35,11 +35,13 @@ WriteXLS <- function(x, ExcelFileName = "R.xls", SheetNames = NULL, perl = "perl
   XLSX <- grepl("\\.XLSX$", toupper(ExcelFileName))
 
   
+  # If 'x' is a list then use that list directly, assuming it is a named list of data tables.
   # If 'x' is a single name, it is either a single data frame or a list of data frames
   # If 'x' is >1 names in a character vector, it is presumed to be a vector of data frame names.
   # If not a list name, create a list of data frames from the vector, for consistency in subsequent processing.
-  if (length(x) == 1)
-  {
+  if (is.list(x)) {
+    DF.LIST <- x
+  } else if (length(x) == 1) {
     TMP <- get(as.character(x), envir = envir)
     
     # is TMP a list and not single data frame    

--- a/man/WriteXLS.Rd
+++ b/man/WriteXLS.Rd
@@ -13,8 +13,11 @@
            envir = parent.frame())
 }
 \arguments{
-  \item{x}{A character vector containing either the names of one or more R
-        data frames, or the single name of a list containing one or more
+  \item{x}{Either: 1. A named list containing one or more R data frames 
+        (the name of each list item will be used as the tab name for each corresponding data frame),
+        2. A character vector containing either the names of one or more R
+        data frames, or 
+        3. the single name of a list containing one or more
 	R data frames, to be exported to the Excel file.}
   \item{ExcelFileName}{The name of the Excel file to be created.
         If the file extension is \emph{.XLS}, an Excel 2003 file will be


### PR DESCRIPTION
Rather than having to mess around providing the name of a list as a string, or the names of multiple data frames, allow the user to directly provide a list of dataframes.
